### PR TITLE
Allow for display of empty sections

### DIFF
--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -104,6 +104,26 @@ class fdmSettings {
 			)
 		);
 
+		// Create a section to change section specific features
+		$sap->add_section(
+			'food-and-drink-menu-settings',	// Page to add this section to
+			array(								// Array of key/value pairs matching the AdminPageSection class constructor variables
+				'id'			=> 'fdm-section-settings',
+				'title'			=> __( 'Sections', 'food-and-drink-menu' ),
+				'description'	=> __( 'Settings that effect each section.', 'food-and-drink-menu' )
+			)
+		);
+		$sap->add_setting(
+			'food-and-drink-menu-settings',
+			'fdm-section-settings',
+			'toggle',
+			array(
+				'id'			=> 'fdm-show-empty-sections',
+				'title'			=> __( 'Show empty', 'food-and-drink-menu' ),
+				'label'			=> __( 'Show sections with no (zero) menu items.', 'food-and-drink-menu' )
+			)
+		);
+		
 		// Create a section to disable specific features
 		$sap->add_section(
 			'food-and-drink-menu-settings',	// Page to add this section to

--- a/views/View.Section.class.php
+++ b/views/View.Section.class.php
@@ -34,11 +34,16 @@ class fdmViewSection extends fdmView {
 			return;
 		}
 
+		$settings = get_option( 'food-and-drink-menu-settings' );
+		$show_empty = $settings['fdm-show-empty-sections'];
+		
 		// Gather data if it's not already set
-		$this->load_section();
+		$this->load_section($show_empty);
 
-		if ( !isset( $this->items ) || ( is_array( $this->items ) && !count( $this->items ) ) ) {
-			return;
+		if( !$show_empty ){
+			if ( !isset( $this->items ) || ( is_array( $this->items ) && !count( $this->items ) ) ) {
+				return;
+			}
 		}
 
 		// Define the classes for this section
@@ -75,7 +80,7 @@ class fdmViewSection extends fdmView {
 	 * Load section data
 	 * @since 1.1
 	 */
-	public function load_section() {
+	public function load_section($show_empty = false) {
 
 		if ( !isset( $this->id ) ) {
 			return;
@@ -95,7 +100,7 @@ class fdmViewSection extends fdmView {
 				),
 			),
 		));
-		if ( !count( $items->posts ) ) {
+		if ( !count( $items->posts ) && !$show_empty ) {
 			return;
 		}
 


### PR DESCRIPTION
One section we have on our menus is for deserts.
As the deserts change all the time the description for this section just reads.

> **Deserts**
> We offer a selection of deserts from our deserts board.

This pull adds an option in the settings to include empty sections (sections with zero items) 
It will default to `False` i.e. previous behavior